### PR TITLE
Simplify the lazy rule_set fetching

### DIFF
--- a/cppcmb.hpp
+++ b/cppcmb.hpp
@@ -2,7 +2,7 @@
  * cppcmb.hpp
  *
  * This file has been merged from multiple source files.
- * Generation date: 2019-04-30 21:05:50.808514
+ * Generation date: 2021-03-01 15:52:04.535674
  *
  * Copyright (c) 2018-2019 Peter Lenkefi
  * Distributed under the MIT License.
@@ -3474,11 +3474,6 @@ namespace detail {
 template <typename>
 inline /* constexpr */ auto rule_set = 0;
 
-template <typename, typename U>
-struct second {
-    using type = U;
-};
-
 } /* namespace detail */
 
 template <typename Val, typename Tag>
@@ -3508,18 +3503,15 @@ auto const name =              \
  * Used to define rules.
  * Generates the function that does the indirect-call.
  */
-#define cppcmb_def(name)                                            \
-template <typename Src>                                             \
-[[nodiscard]] constexpr auto                                        \
-cppcmb_parse_rule(decltype(name), ::cppcmb::reader<Src> const& r) { \
-    using tag_type = typename decltype(name)::tag_type;             \
-    auto const& p = ::cppcmb::detail::rule_set<                     \
-        typename ::cppcmb::detail::second<Src, tag_type>::type      \
-    >;                                                              \
-    return p.apply(r);                                              \
-}                                                                   \
-template <>                                                         \
-inline /* constexpr */ auto                                         \
+#define cppcmb_def(name)                                                   \
+template <typename Src, typename Lazy = typename decltype(name)::tag_type> \
+[[nodiscard]] constexpr auto                                               \
+cppcmb_parse_rule(decltype(name), ::cppcmb::reader<Src> const& r) {        \
+    auto const& p = ::cppcmb::detail::rule_set<Lazy>;                      \
+    return p.apply(r);                                                     \
+}                                                                          \
+template <>                                                                \
+inline /* constexpr */ auto                                                \
 ::cppcmb::detail::rule_set<typename decltype(name)::tag_type>
 
 } /* namespace cppcmb */

--- a/source/parsers/rule.hpp
+++ b/source/parsers/rule.hpp
@@ -24,11 +24,6 @@ namespace detail {
 template <typename>
 inline /* constexpr */ auto rule_set = 0;
 
-template <typename, typename U>
-struct second {
-    using type = U;
-};
-
 } /* namespace detail */
 
 template <typename Val, typename Tag>
@@ -58,18 +53,15 @@ auto const name =              \
  * Used to define rules.
  * Generates the function that does the indirect-call.
  */
-#define cppcmb_def(name)                                            \
-template <typename Src>                                             \
-[[nodiscard]] constexpr auto                                        \
-cppcmb_parse_rule(decltype(name), ::cppcmb::reader<Src> const& r) { \
-    using tag_type = typename decltype(name)::tag_type;             \
-    auto const& p = ::cppcmb::detail::rule_set<                     \
-        typename ::cppcmb::detail::second<Src, tag_type>::type      \
-    >;                                                              \
-    return p.apply(r);                                              \
-}                                                                   \
-template <>                                                         \
-inline /* constexpr */ auto                                         \
+#define cppcmb_def(name)                                                   \
+template <typename Src, typename Lazy = typename decltype(name)::tag_type> \
+[[nodiscard]] constexpr auto                                               \
+cppcmb_parse_rule(decltype(name), ::cppcmb::reader<Src> const& r) {        \
+    auto const& p = ::cppcmb::detail::rule_set<Lazy>;                      \
+    return p.apply(r);                                                     \
+}                                                                          \
+template <>                                                                \
+inline /* constexpr */ auto                                                \
 ::cppcmb::detail::rule_set<typename decltype(name)::tag_type>
 
 } /* namespace cppcmb */


### PR DESCRIPTION
Originally, the code uses a metafunction `second` to delay the time when `rule_set<T>` executes, because this metafunction needs an undetermined argument `Src`. However, if the compiler is smart enough (IDK whether this case exists), it can find that `Src` is actually not used and evaluate it immediately.

What I have done is to put the type to a template parameter, so that the value of `rule_set<T>` must be delayed until `cppcmb_parse_rule` being invoked. It also simplifies the code. It is still IFNDR though.

Apart from that, I doubt the use of `cppcmb_parse_rule` inside `rule_t::apply` is also IFNDR.